### PR TITLE
Move and redesign progress bar

### DIFF
--- a/src/components/TheProgressBar.vue
+++ b/src/components/TheProgressBar.vue
@@ -39,6 +39,7 @@ export default {
         mouseup: vm.handleSeek,
         mouseleave: vm.resetSeek,
       },
+      offset: 40,
     }
   },
   computed: {
@@ -74,8 +75,8 @@ export default {
       this.emitSeek(position)
     },
     initSeek (e) {
-      const x = e.offsetX || e.touches[0].pageX
-      this.seekWidth = window.innerWidth
+      const x = e.offsetX || e.touches[0].pageX - this.offset / 2
+      this.seekWidth = window.innerWidth - this.offset
       this.setSeekPosition(this.calcProgress(x))
       window.addEventListener('touchmove', this.moveSeek, true)
       window.addEventListener('mousemove', this.moveSeek)
@@ -91,12 +92,12 @@ export default {
     moveSeek (e) {
       e.preventDefault()
       e.stopPropagation()
-      const x = e.offsetX || e.touches[0].pageX
+      const x = e.offsetX || e.touches[0].pageX - this.offset / 2
       this.setSeekPosition(this.calcProgress(x))
     },
     handleSeek (e) {
       this.resetSeek()
-      const x = e.offsetX || e.changedTouches[0].pageX
+      const x = e.offsetX || e.changedTouches[0].pageX - this.offset / 2
       this.seek(this.calcProgress(x))
       this.setAutoSync(true)
     },
@@ -115,12 +116,14 @@ export default {
 <style lang="scss" scoped>
 .the-progress-bar {
   position: absolute;
-  bottom: 0;
+  bottom: 20px;
   z-index: 200;
-  width: 100%;
+  width: calc(100% - 40px);
+  left: 20px;
+  right: 20px;
   height: 20px;
   cursor: pointer;
-  transform-origin: bottom;
+  transform-origin: center;
   transition: transform .2s var(--ease-io-cubic), opacity .35s;
   opacity: 1;
   -webkit-tap-highlight-color: transparent;
@@ -140,23 +143,26 @@ export default {
   }
 }
 .progress {
-  height: 3px;
+  overflow: hidden;
+  height: 6px;
+  border-radius: 3px;
   position: absolute;
   width: 100%;
-  bottom: 0;
+  top: calc(14px / 2);
   background-image: linear-gradient(var(--theme-color), var(--theme-color));
   background-repeat: no-repeat;
   background-size: 0% 100%;
   transition-property: background-size;
   transition-timing-function: linear;
 
-  // &:before {
-  //   content: '';
-  //   position: absolute;
-  //   z-index: -1;
-  //   width: 100vw;
-  //   height: 100%;
-  //   left: 0;
-  // }
+  &:before {
+    content: '';
+    position: absolute;
+    z-index: -1;
+    width: 100%;
+    height: 100%;
+    left: 0;
+    background-color: rgba(255,255,255,.85);
+  }
 }
 </style>

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -17,7 +17,7 @@
     </base-page-transition>
     <the-header/>
     <the-lyrics-screen/>
-    <div class="the-controls" :class="{'--center': !delayedScrollStatus}">
+    <div class="the-controls" :class="{'--center': !delayedScrollStatus, '--offset': hasProgress && (synced || normal)}">
       <now-playing/>
       <transition name="switch-trans" mode="out-in">
         <base-button v-if="scrollOverride" :key="delayedScrollStatus" class="resume-button" @click.native="setScroll(true)">
@@ -27,7 +27,7 @@
       <delay-bar v-if="synced" hideTitle/>
       <div class="spacer"/>
     </div>
-    <the-menu-toggle v-if="acceptance || privacy"/>
+    <the-menu-toggle v-if="acceptance || privacy" :class="{'--offset': hasProgress && (synced || normal)}" />
     <update-toast v-if="!$dev"/>
     <the-keys/>
   </div>
@@ -85,6 +85,9 @@ export default {
       privacy: state => state.privacyPolicy,
       report: state => state.report,
       acceptance: state => state.user.acceptance,
+      hasProgress (state) {
+        return state.playback.track.length && state.playback.progress
+      },
     }),
     ...mapGetters({
       hasPlayback: 'playback/hasPlayback',
@@ -152,9 +155,14 @@ export default {
     z-index: 9;
     animation: fade-in .25s ease-out;
     --font-color: rgba(255,255,255,.95);
+    transition: transform .25s var(--ease-io-cubic);
 
     @media only screen and (min-width: 640px) {
       display: none;
+    }
+
+    &.--offset {
+      transform: translateY(-30px);
     }
   }
 
@@ -168,6 +176,11 @@ export default {
     width: calc(100% - 40px);
     pointer-events: none;
     fill: var(--font-color);
+    transition: transform .25s var(--ease-io-cubic);
+
+    &.--offset {
+      transform: translateY(-30px);
+    }
 
     > * {
       pointer-events: auto;


### PR DESCRIPTION
Move progress bar up a bit to make it more accessible on touch devices with gesture navigation at the very bottom.
Idea is to make it more part of the media controls in general.